### PR TITLE
fix/17 Google Mapを呼び出した際の警告の解消

### DIFF
--- a/frontend/src/app/components/Map.tsx
+++ b/frontend/src/app/components/Map.tsx
@@ -26,8 +26,31 @@ export default function Map({ view, setView }: MapProps) {
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
   })
 
-  if (loadError) return <div>地図の読み込みに失敗しました</div>;
-  if (!isLoaded) return <div>読み込み中...</div>;
+  if (loadError) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-2xl font-bold text-red-600 mb-2">
+            地図の読み込みに失敗しました
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isLoaded) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <div className="text-center flex flex-col items-center">
+          <span className="loading loading-spinner loading-lg text-neutral"></span>
+          <div className="text-lg font-semibold mt-4">
+            読み込み中…
+          </div>
+        </div>
+      </div>
+    );
+  }
+
 
   return (
     <div className="relative w-full h-full">


### PR DESCRIPTION
## Map.tsxを複数回呼び出した際の警告を解消
- LoadScriptではなくuseJsApiLoaderを使用するように変更
- この変更によって必要になった読み込み中、読み込み失敗時の処理を追加