### PR TITLE
issue#12: ハンバーガーメニューからの画面遷移の実装

### DIFF
--- a/frontend/src/app/components/MainMenu.tsx
+++ b/frontend/src/app/components/MainMenu.tsx
@@ -35,19 +35,19 @@ export default function MainMenu({ open, onClose }: Props) {
         </button>
         <button
           className="btn btn-outline btn-sm justify-start"
-          onClick={() => go("/")}
+          onClick={() => go("/post")}
         >
           投稿する
         </button>
         <button
           className="btn btn-outline btn-sm justify-start"
-          onClick={() => go("/")}
+          onClick={() => go("/user-setting")}
         >
           個人設定
         </button>
         <button
           className="btn btn-outline btn-sm justify-start"
-          onClick={() => go("/")}
+          onClick={() => go("/usage")}
         >
           使い方
         </button>


### PR DESCRIPTION
# 概要
メインメニューのボタンをクリックすると，該当のページに遷移する．

# 実装要件
- 「投稿する」ボタンをクリックすると，投稿ページへ遷移する
- 「個人設定」ボタンをクリックすると，個人設定ページへ遷移する
- 「使い方」ボタンをクリックすると，使い方ページへ遷移する