### PR TITLE
issue #51 タイムラインの各投稿に投稿時刻を表示

### DIFF
--- a/frontend/src/app/components/PostCard.tsx
+++ b/frontend/src/app/components/PostCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { formatPostDate } from '@/lib/dateUtils'
 import type { Post } from '@/types/post';
 
 interface PostCardProps {
@@ -7,7 +8,12 @@ interface PostCardProps {
 
 const PostCard = ({ post }: PostCardProps) => {
   return (
-    <div className="flex space-x-3 p-4 border-b border-gray-200">
+    <div className="relative flex space-x-3 p-4 border-b border-gray-200">
+      {/* Created At */}
+      <div className="absolute top-4 right-4 text-xs text-gray-400">
+        {post.created_at && formatPostDate(post.created_at)}
+      </div>
+
       {/* Avatar */}
       <div className="flex-shrink-0">
         <div className="w-12 h-12 rounded-full overflow-hidden">
@@ -26,7 +32,7 @@ const PostCard = ({ post }: PostCardProps) => {
         {/* User Info */}
         <div className="flex items-center space-x-2">
           <span className="font-bold text-base text-black">{post.username}</span>
-          <span className="text-xs text-gray-500">{post.location}</span>
+          {post.location && <span className="text-xs text-gray-500">{post.location}</span>}
         </div>
 
         {/* Post Body */}

--- a/frontend/src/app/components/Timeline.tsx
+++ b/frontend/src/app/components/Timeline.tsx
@@ -72,6 +72,7 @@ const Timeline = ({ view, setView, isPC }: TimelineProps) => {
         likes: [],
         likeCount: 0,
         replies: [], // PostCardで length を見るので必ず入れる
+        created_at: row.created_at, // これを追加
       }))
 
       setPosts(mapped)

--- a/frontend/src/lib/dateUtils.ts
+++ b/frontend/src/lib/dateUtils.ts
@@ -1,0 +1,31 @@
+export function formatPostDate(createdAt: string): string {
+  const date = new Date(createdAt);
+  const now = new Date();
+
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 1) {
+    return "たった今";
+  }
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes}分前`;
+  }
+
+  if (diffHours < 24) {
+    return `${diffHours}時間前`;
+  }
+
+  if (diffDays < 7) {
+    return `${diffDays}日前`;
+  }
+
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+
+  return `${y}/${m}/${d}`;
+}

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,9 +1,12 @@
+import type { Reply } from "./reply";
+
 export interface Post {
-  post_id: number;
-  user_id: string;
+  id: string;
+  username: string;
+  location?: string;
+  imageUrl?: string;
+  body: string;
+  likeCount: number;
+  replies: Reply[];
   created_at: string;
-  latitude: number | null;
-  longitude: number | null;
-  image_url: string | null;
-  caption: string | null;
 }

--- a/frontend/src/types/reply.ts
+++ b/frontend/src/types/reply.ts
@@ -1,0 +1,7 @@
+export interface Reply {
+  id: string;
+  post_id: string;
+  user_id: string;
+  body: string;
+  created_at: string;
+}


### PR DESCRIPTION
## 概要

issue #51 に対応し、タイムラインの各投稿に投稿時刻を表示するようにしました。

## 変更内容

- 投稿カード右上に投稿時刻を表示
- `created_at` を元に相対時間（○分前 / ○時間前 / 日付）で表示
- 日付表示用のユーティリティ関数を追加
- 投稿型定義を整理（`any` の除去）

## 確認方法

- タイムラインを表示し、各投稿の右上に投稿時刻が表示されること
-  ~~新規投稿・既存投稿の両方で正しく表示されること~~
- PC / モバイルでレイアウトが崩れないこと

## 関連 Issue

- #51
