### PR TITLE
issue #60 いいねが反映されるように

### DIFF
--- a/frontend/src/app/components/PostCard.tsx
+++ b/frontend/src/app/components/PostCard.tsx
@@ -1,12 +1,65 @@
+'use client'
+
+import { useState } from 'react';
 import Image from 'next/image';
-import { formatPostDate } from '@/lib/dateUtils'
+import { formatPostDate } from '@/lib/dateUtils';
+import { createClient } from '@/lib/supabase/client';
 import type { Post } from '@/types/post';
 
+const supabase = createClient()
+
 interface PostCardProps {
-  post: Post;
+  post: Post
 }
 
 const PostCard = ({ post }: PostCardProps) => {
+  const [isLiked, setIsLiked] = useState(post.isLiked)
+  const [likeCount, setLikeCount] = useState(post.likeCount)
+  const [pending, setPending] = useState(false)
+
+  const handleLikeClick = async () => {
+    if (pending) return
+    setPending(true)
+
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setPending(false)
+      return
+    }
+
+    const nextLiked = !isLiked
+
+    //楽観更新（即UI反映）
+    setIsLiked(nextLiked)
+    setLikeCount(prev => prev + (nextLiked ? 1 : -1))
+
+    try {
+      if (nextLiked) {
+        //いいね追加
+        const { error } = await supabase.from('favorites').insert({
+          post_id: post.post_id,
+          user_id: user.id,
+        })
+        if (error) throw error
+      } else {
+        //いいね解除
+        const { error } = await supabase
+          .from('favorites')
+          .delete()
+          .eq('post_id', post.post_id)
+          .eq('user_id', user.id)
+        if (error) throw error
+      }
+    } catch (e) {
+      // 失敗したら巻き戻す
+      setIsLiked(!nextLiked)
+      setLikeCount(prev => prev - (nextLiked ? 1 : -1))
+      console.error(e)
+    } finally {
+      setPending(false)
+    }
+  }
+
   return (
     <div className="relative flex space-x-3 p-4 border-b border-gray-200">
       {/* Created At */}
@@ -31,8 +84,10 @@ const PostCard = ({ post }: PostCardProps) => {
       <div className="flex-1">
         {/* User Info */}
         <div className="flex items-center space-x-2">
-          <span className="font-bold text-base text-black">{post.username}</span>
-          {post.location && <span className="text-xs text-gray-500">{post.location}</span>}
+          <span className="text-base text-black">{post.username}</span>
+          {post.location && (
+            <span className="text-xs text-gray-500">{post.location}</span>
+          )}
         </div>
 
         {/* Post Body */}
@@ -53,9 +108,15 @@ const PostCard = ({ post }: PostCardProps) => {
 
         {/* Action Buttons */}
         <div className="flex items-center justify-start space-x-8 mt-3 text-gray-500">
-          <button className="flex items-center space-x-1 hover:text-pink-500 cursor-pointer">
+          <button
+            type="button"
+            onClick={handleLikeClick}
+            disabled={pending}
+            className={`flex items-center space-x-1 cursor-pointer ${isLiked ? 'text-pink-500' : 'hover:text-pink-500'
+              } ${pending ? 'opacity-60 cursor-not-allowed' : ''}`}
+          >
             <span role="img" aria-label="likes">❤️</span>
-            <span>{post.likeCount}</span>
+            <span>{likeCount}</span>
           </button>
           <button className="flex items-center space-x-1 hover:text-blue-500 cursor-pointer">
             <span role="img" aria-label="replies">💬</span>

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,16 +1,19 @@
 import type { Reply } from "./reply";
-
 export interface Post {
-  id: string;
+  post_id: number; // ここが主キー（int8）
+  user_id: string; // uuid
   username: string;
   location?: string;
-  imageUrl?: string;
-  body: string;
-  likeCount: number;
-  replies: Reply[];
+
+  caption: string | null;
+  image_url: string | null;
+
   created_at: string;
   latitude: number | null;
   longitude: number | null;
-  image_url: string | null;
-  caption: string | null;
+
+  likeCount: number;
+  isLiked: boolean;
+
+  replies: Reply[];
 }


### PR DESCRIPTION
## 概要
投稿に対する「いいね」機能を実装し、ユーザー操作が即座に画面へ反映されるようにしました。

## 変更内容
- favorites テーブルを利用したいいねの追加・解除処理を実装
- 投稿一覧取得時に likeCount / isLiked を合流
- PostCard 内で楽観的UI更新（即時反映）を実装
- post_id を正しく使用するよう統一

## 動作確認
- ❤️を押すと即座に数値と色が切り替わる
- 再読み込み後もいいね状態が保持される
- 他の投稿に影響しないことを確認

## 関連 Issue
- issue #60 