### PR TITLE
issue#40: ハンバーガーメニュー押したらメニューが横からぬるっと表示するアニメーション

### DIFF
--- a/frontend/src/app/components/MainMenu.tsx
+++ b/frontend/src/app/components/MainMenu.tsx
@@ -26,7 +26,7 @@ export default function MainMenu({ open, onClose }: Props) {
     <>
       {/* overlay */}
       <div
-        className={`fixed inset-0 z-40 transition-opacity duration-300 ${
+        className={`fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ${
           open
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none"


### PR DESCRIPTION
- ハンバーガーメニューを開いたときのアニメーション追加
- メインメニューを開いている間はメイン画面の操作ができないため，画面を暗くするように変更した