### PR TITLE
issue #70 いいね・コメントアイコンのデザインをかえたい 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "digital-contents",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/ssr": "^0.8.0",
@@ -1104,6 +1105,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/ssr": "^0.8.0",

--- a/frontend/src/app/components/ActionButtons.tsx
+++ b/frontend/src/app/components/ActionButtons.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { HeartIcon as HeartOutlineIcon, ChatBubbleLeftIcon, HandThumbUpIcon as HandThumbUpOutlineIcon } from '@heroicons/react/24/outline';
+import { HeartIcon as HeartSolidIcon, HandThumbUpIcon as HandThumbUpSolidIcon } from '@heroicons/react/24/solid';
+
+interface ActionButtonsProps {
+  // Props for post actions
+  isLiked?: boolean;
+  likeCount?: number;
+  onLike?: () => void;
+  commentCount?: number;
+  onOpenComments?: () => void;
+
+  // Props for comment specific good button (optional)
+  isCommentLiked?: boolean;
+  commentLikeCount?: number;
+  onCommentLike?: () => void;
+}
+
+const ActionButtons: React.FC<ActionButtonsProps> = ({
+  isLiked,
+  likeCount,
+  onLike,
+  commentCount,
+  onOpenComments,
+  isCommentLiked,
+  commentLikeCount,
+  onCommentLike,
+}) => {
+  const showPostActions = onLike !== undefined && onOpenComments !== undefined;
+  const showCommentActions = onCommentLike !== undefined;
+
+  return (
+    <div className="flex items-center space-x-4 text-gray-500">
+      {/* Post Actions */}
+      {showPostActions && (
+        <>
+          {/* Like Button */}
+          <button
+            onClick={onLike}
+            className="flex items-center space-x-1 p-2 rounded-full hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+            aria-label={isLiked ? 'いいねを取り消す' : 'いいねする'}
+          >
+            {isLiked ? (
+              <HeartSolidIcon className="w-5 h-5 text-red-500" />
+            ) : (
+              <HeartOutlineIcon className="w-5 h-5 hover:text-red-500" />
+            )}
+            <span className="text-sm font-medium">{likeCount ?? 0}</span>
+          </button>
+
+          {/* Comment Button */}
+          <button
+            onClick={onOpenComments}
+            className="flex items-center space-x-1 p-2 rounded-full hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+            aria-label="コメントを開く"
+          >
+            <ChatBubbleLeftIcon className="w-5 h-5 hover:text-blue-500" />
+            <span className="text-sm font-medium">{commentCount ?? 0}</span>
+          </button>
+        </>
+      )}
+
+      {/* Comment Good Button - Optional */}
+      {showCommentActions && (
+        <button
+          onClick={onCommentLike}
+          className="flex items-center space-x-1 p-2 rounded-full hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+          aria-label={isCommentLiked ? 'グッドを取り消す' : 'グッドする'}
+        >
+          {isCommentLiked ? (
+            <HandThumbUpSolidIcon className="w-5 h-5 text-blue-500" />
+          ) : (
+            <HandThumbUpOutlineIcon className="w-5 h-5 hover:text-blue-500" />
+          )}
+          <span className="text-sm font-medium">{commentLikeCount ?? 0}</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ActionButtons;

--- a/frontend/src/app/components/CommentItem.tsx
+++ b/frontend/src/app/components/CommentItem.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import type { User } from '@supabase/supabase-js'
 import type { Comment } from '@/types/comment'
 import { formatPostDate } from '@/lib/dateUtils'
+import ActionButtons from './ActionButtons'
 
 interface CommentItemProps {
   comment: Comment
@@ -46,24 +47,12 @@ const CommentItem = ({ comment, user, toggleReaction, style }: CommentItemProps)
 
         <div className="mt-1 text-sm whitespace-pre-wrap break-words leading-relaxed">{comment.content}</div>
 
-        <div className="mt-2 flex items-center gap-1">
-          <button
-            type="button"
-            className={[
-              'btn btn-ghost btn-sm btn-circle',
-              comment.isLiked ? 'text-primary' : 'text-base-content/60',
-            ].join(' ')}
-            aria-label={comment.isLiked ? 'いいねを取り消す' : 'いいねする'}
-            onClick={() => toggleReaction(comment.comment_id, comment.isLiked)}
-            disabled={!user}
-          >
-            <span className={['text-lg leading-none', comment.isLiked ? 'animate-[reactionPop_180ms_ease-out]' : ''].join(' ')} aria-hidden>
-              👍
-            </span>
-          </button>
-          {comment.likeCount > 0 && (
-            <span className="text-xs text-base-content/60">{comment.likeCount}</span>
-          )}
+        <div className="mt-1 -ml-2">
+          <ActionButtons
+            isCommentLiked={comment.isLiked}
+            commentLikeCount={comment.likeCount}
+            onCommentLike={user ? () => toggleReaction(comment.comment_id, comment.isLiked) : undefined}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/PostCard.tsx
+++ b/frontend/src/app/components/PostCard.tsx
@@ -6,6 +6,10 @@ import { formatPostDate } from '@/lib/dateUtils'
 import { createClient } from '@/lib/supabase/client'
 import type { Post } from '@/types/post'
 
+import { MapPinIcon } from '@heroicons/react/24/outline'
+
+import ActionButtons from './ActionButtons'
+
 const supabase = createClient()
 
 interface PostCardProps {
@@ -93,15 +97,15 @@ const PostCard = ({ post, onCommentClick, onMoveMap }: PostCardProps) => {
 
           {post.location && <span className="text-xs text-gray-500">{post.location}</span>}
 
-          {/* 地図移動ボタン（仮） */}
+          {/* 地図移動ボタン */}
           {post.latitude && post.longitude && (
             <button
               type="button"
-              className="btn btn-xs btn-outline gap-1 text-gray-700"
+              className="btn btn-xs btn-outline gap-1 text-gray-700 cursor-pointer"
               title="地図で場所を見る"
               onClick={() => onMoveMap(post.latitude!, post.longitude!)}
             >
-              <span aria-hidden>📍</span>
+              <MapPinIcon className="w-4 h-4" aria-hidden="true" />
               地図で見る
             </button>
           )}
@@ -124,30 +128,14 @@ const PostCard = ({ post, onCommentClick, onMoveMap }: PostCardProps) => {
         )}
 
         {/* Action Buttons */}
-        <div className="flex items-center justify-start space-x-8 mt-3 text-gray-500">
-          <button
-            type="button"
-            onClick={handleLikeClick}
-            disabled={pending}
-            className={`flex items-center space-x-1 cursor-pointer ${isLiked ? 'text-pink-500' : 'hover:text-pink-500'
-              } ${pending ? 'opacity-60 cursor-not-allowed' : ''}`}
-          >
-            <span role="img" aria-label="likes">
-              ❤️
-            </span>
-            <span>{likeCount}</span>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => onCommentClick(post.post_id)}
-            className="flex items-center space-x-1 hover:text-blue-500 cursor-pointer"
-          >
-            <span role="img" aria-label="replies">
-              💬
-            </span>
-            <span>{post.commentCount}</span>
-          </button>
+        <div className="mt-3">
+          <ActionButtons
+            isLiked={isLiked}
+            likeCount={likeCount}
+            onLike={handleLikeClick}
+            commentCount={post.commentCount}
+            onOpenComments={() => onCommentClick(post.post_id)}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
いいね・コメント周りで使用していた絵文字（❤️ 💬）を廃止し、
Heroicons を用いた SVG アイコンに置き換えました。

UI の統一感向上と、状態（いいね済み / 未いいね）が
視覚的に分かりやすくなることを目的としています。

## 変更内容
- 投稿のいいねアイコンを Heroicons（HeartIcon）に置き換え
  - 未いいね：outline
  - いいね済み：solid + 強調色
- 投稿のコメントアイコンを ChatBubbleLeftIcon（outline）に置き換え
- コメントのグッド（いいね）アイコンを HandThumbUpIcon に置き換え
  - 未グッド：outline
  - グッド済み：solid + 強調色
- 絵文字（環境依存文字）をすべて削除
- Tailwind / DaisyUI のクラスで色・サイズ・hover 表現を統一

## 目的
- 環境依存による表示差異をなくす
- SNS らしい一貫した UI にする
- 状態変化が直感的に分かるようにする

## 動作確認
- いいね / 解除時にアイコンが切り替わること
- コメント表示・コメントのグッドが正常に動作すること
- 確認前に`npm ci`してください

## 関連Issue
- #70
